### PR TITLE
Conversion to VS2015

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,4 @@ pip-log.txt
 #Mr Developer
 .mr.developer.cfg
 
+**/src/.vs/


### PR DESCRIPTION
Moving from VS2013 to VS2015
- updated gitignore to exclude .vs diretory

Resolves #1